### PR TITLE
Fix swap doc

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -4226,6 +4226,14 @@
     swapDoc: methodOp(function(doc) {
       var old = this.doc;
       old.cm = null;
+      
+      // change mode
+      old._sawCollapsedSpans = sawCollapsedSpans;
+      sawCollapsedSpans = doc._sawCollapsedSpans !== undefined ? doc._sawCollapsedSpans : false;
+
+      old._sawReadOnlySpans = sawReadOnlySpans;
+      sawReadOnlySpans = doc._sawReadOnlySpans !== undefined ? doc._sawReadOnlySpans : false;
+      
       attachDoc(this, doc);
       clearCaches(this);
       resetInput(this);


### PR DESCRIPTION
Fix problem during swap doc with collapsed lines to doc without collapsed lines and empty content.
It throw error `There is no line 1 in the document.`
